### PR TITLE
Issue 1 / Update elm-css dependency to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # elm-css-normalize
 
-A port of normalize.css for elm-css
+A port of normalize.css for elm-css.
+
+
+## Usage
+
+Import the `Css.Normalize` module in your Stylesheets.elm file (or where you are building your elm-css) and include `Css.Normalize.css` in your list of CSS. See the examples folder for two uses; as inline styles and as .css file.
+
+
+## Development/Testing
+
+Build a CSS file by running:
+
+`elm-css examples/Stylesheets.elm`
+
+Build an example HTML file with inline CSS by running:
+
+`elm make examples/Main.elm`
+
+Or using the reactor:
+
+`elm reactor` then navigate to examples/Main.elm
+

--- a/README.md
+++ b/README.md
@@ -3,24 +3,21 @@
 A port of normalize.css for elm-css.
 
 
-## Usage
+## Documentation
 
-Import the `Css.Normalize` module in your Stylesheets.elm file (or where you are building your elm-css) and include `Css.Normalize.css` in your list of CSS. See the examples folder for two uses; as inline styles and as .css file.
+See the package documentation at: http://package.elm-lang.org/packages/scottcorgan/elm-css-normalize/latest/Css-Normalize
 
 
 ## Development/Testing
 
 Build a CSS file by running:
 
-`elm-css examples/Stylesheets.elm`
+`cd examples && elm-css Stylesheets.elm`
 
 Build an example HTML file with inline CSS by running:
 
-`elm package install scottcorgan/elm-html-template && elm make examples/Main.elm`
+`cd examples && elm package install && elm make Main.elm`
 
 Or using the reactor:
 
-`elm package install scottcorgan/elm-html-template && elm reactor` then navigate to examples/Main.elm
-
-Note that github.com/scottcorgan/elm-html-template is required for development/testing and has to be manually added.
-
+`cd examples && elm package install && elm reactor` then click Main.elm in the browser.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Build a CSS file by running:
 
 Build an example HTML file with inline CSS by running:
 
-`elm make examples/Main.elm`
+`elm package install scottcorgan/elm-html-template && elm make examples/Main.elm`
 
 Or using the reactor:
 
-`elm reactor` then navigate to examples/Main.elm
+`elm package install scottcorgan/elm-html-template && elm reactor` then navigate to examples/Main.elm
+
+Note that github.com/scottcorgan/elm-html-template is required for development/testing and has to be manually added.
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,10 +10,7 @@
         "Css.Normalize"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "rtfeldman/elm-css": "4.0.2 <= v < 7.0.0",
-        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0"
+        "rtfeldman/elm-css": "4.0.2 <= v < 7.0.0"
     },
     "elm-version": "0.17.1 <= v < 0.18.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,8 +13,7 @@
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
         "rtfeldman/elm-css": "4.0.2 <= v < 7.0.0",
-        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
-        "scottcorgan/elm-html-template": "1.0.0 <= v < 2.0.0"
+        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.17.1 <= v < 0.18.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "rtfeldman/elm-css": "4.0.2 <= v < 5.0.0",
+        "rtfeldman/elm-css": "4.0.2 <= v < 7.0.0",
         "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
         "scottcorgan/elm-html-template": "1.0.0 <= v < 2.0.0"
     },

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -19,7 +19,7 @@ main =
 
 compiledCss : String
 compiledCss =
-    Css.Normalize.css
+    [ Css.Normalize.css ]
         |> Css.File.compile
         |> .css
 

--- a/examples/Stylesheets.elm
+++ b/examples/Stylesheets.elm
@@ -1,0 +1,25 @@
+port module Stylesheets exposing (..)
+
+import Css.File exposing (..)
+import Html exposing (div)
+import Html.App as Html
+
+import Css.Normalize
+
+
+port files : CssFileStructure -> Cmd msg
+
+
+cssFiles : CssFileStructure
+cssFiles =
+    toFileStructure [ ( "normalize.css", compile [ Css.Normalize.css ] ) ]
+
+
+main : Program Never
+main =
+    Html.program
+        { init = ( (), files cssFiles )
+        , view = \_ -> (div [] [])
+        , update = \_ _ -> ( (), Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.1.3",
+    "summary": "Examples for the port of normalize.css for elm-css",
+    "repository": "https://github.com/scottcorgan/elm-css-normalize.git",
+    "license": "MIT",
+    "source-directories": [
+        "./"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.5 <= v < 5.0.0",
+        "elm-lang/html": "1.1.0 <= v < 2.0.0",
+        "rtfeldman/elm-css": "4.0.2 <= v < 7.0.0",
+        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
+        "scottcorgan/elm-css-normalize": "1.1.3 <= v < 2.0.0",
+        "scottcorgan/elm-html-template": "1.0.0 <= v < 2.0.0"
+    },
+    "elm-version": "0.17.1 <= v < 0.18.0"
+}


### PR DESCRIPTION
Allows the module to be used with the latest version of elm-css (6.1.0).

Also adds a Stylesheet.elm file for building a css file (for dev), adds content to the readme file and removes the dependency on scottcorgan/elm-html-template which was only used in the example and not when included as a dependency.
