### PR TITLE
Update elm-css to v8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 elm-stuff
 examples/elm-stuff
+examples/normalize.css

--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css": "7.0.0 <= v < 8.0.0"
+        "rtfeldman/elm-css": "8.0.0 <= v < 9.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/Stylesheets.elm
+++ b/examples/Stylesheets.elm
@@ -13,11 +13,6 @@ cssFiles =
     toFileStructure [ ( "normalize.css", compile [ Css.Normalize.css ] ) ]
 
 
-main : Program Never () msg
+main : CssCompilerProgram
 main =
-    Html.program
-        { init = ( (), files cssFiles )
-        , view = \_ -> (div [] [])
-        , update = \_ _ -> ( (), Cmd.none )
-        , subscriptions = \_ -> Sub.none
-        }
+    Css.File.compiler files cssFiles

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css": "7.0.0 <= v < 8.0.0",
+        "rtfeldman/elm-css": "8.0.0 <= v < 9.0.0",
         "rtfeldman/elm-css-helpers": "2.0.1 <= v < 3.0.0",
         "scottcorgan/elm-html-template": "1.0.1 <= v < 2.0.0"
     },

--- a/src/Css/Normalize.elm
+++ b/src/Css/Normalize.elm
@@ -102,11 +102,11 @@ snippets =
     , each [ article, (selector "aside"), footer, header, nav, section ]
         [ display block ]
     , h1
-        [ fontSize (em 2)
-        , margin2 (em 0.67) zero
+        [ fontSize (Css.em 2)
+        , margin2 (Css.em 0.67) zero
         ]
     , selector "figcaption figure, main" [ display block ]
-    , selector "figure" [ margin2 (em 1) (px 40) ]
+    , selector "figure" [ margin2 (Css.em 1) (px 40) ]
     , hr
         [ boxSizing contentBox
         , height zero
@@ -114,7 +114,7 @@ snippets =
         ]
     , pre
         [ fontFamilies [ "monospace", "monospace" ]
-        , fontSize (em 1)
+        , fontSize (Css.em 1)
         ]
     , a
         [ backgroundColor transparent
@@ -132,7 +132,7 @@ snippets =
     , each [ selector "b", strong ] [ fontWeight bolder ]
     , each [ code, selector "kbd", selector "samp" ]
         [ fontFamilies [ "monospace", "monospace" ]
-        , fontSize (em 1)
+        , fontSize (Css.em 1)
         ]
     , selector "dfn" [ fontStyle italic ]
     , selector "mark"
@@ -146,8 +146,8 @@ snippets =
         , position relative
         , verticalAlign baseline
         ]
-    , selector "sub" [ bottom (em -0.25) ]
-    , selector "sup" [ top (em -0.5) ]
+    , selector "sub" [ bottom (Css.em -0.25) ]
+    , selector "sup" [ top (Css.em -0.5) ]
     , each [ audio, video ] [ display inlineBlock ]
     , selector "audio:not([controls])"
         [ display none
@@ -189,7 +189,7 @@ snippets =
     , fieldset
         [ border3 (px 1) solid (hex "c0c0c0")
         , margin2 zero (px 2)
-        , padding3 (em 0.35) (em 0.625) (em 0.75)
+        , padding3 (Css.em 0.35) (Css.em 0.625) (Css.em 0.75)
         ]
     , legend
         [ boxSizing borderBox


### PR DESCRIPTION
Hey, thanks for writing this library.
I've updated elm-css to v8.
I had to change the `em` units to `Css.em`, because there's also `Css.Elements.em`.