### PR TITLE
Upgrade to elm-css v11.0.0

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css": "9.0.0 <= v < 10.0.0"
+        "rtfeldman/elm-css": "11.0.0 <= v < 12.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css": "9.0.0 <= v < 10.0.0",
+        "rtfeldman/elm-css": "11.0.0 <= v < 12.0.0",
         "rtfeldman/elm-css-helpers": "2.1.0 <= v < 3.0.0",
         "scottcorgan/elm-html-template": "1.0.1 <= v < 2.0.0"
     },


### PR DESCRIPTION
Simple upgrade to elm-css v11.0.0. Tested by compiling the example stylesheet.